### PR TITLE
fmt is not used crash

### DIFF
--- a/go/file_linux.go
+++ b/go/file_linux.go
@@ -1,7 +1,7 @@
 package platform_device_id
 
 import (
-	"fmt"
+	// "fmt"
 	"os/exec"
 
 	"github.com/pkg/errors"


### PR DESCRIPTION
Under Linux, the `fmt` import stopped compilation.